### PR TITLE
Add an error predicate to complement success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/Gemfile.lock
-/.rvmrc
-/pkg
 /.bundle
+/.rvmrc
+/Gemfile.lock
+/pkg
 /vendor

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ result.stderr   # => ""
 result.output   # => "Tue Nov 26 14:45:03 EST 2013\n" (combined stdout + stderr)
 result.status   # => 0
 result.success? # => true
+result.error?   # => false
 result.pid      # => 32157
 ```
 The program and its arguments can be passed as an array:

--- a/lib/komenda/process.rb
+++ b/lib/komenda/process.rb
@@ -28,7 +28,7 @@ module Komenda
     def wait_for
       raise 'Process not started' unless started?
       @thread.join
-      if @process_builder.fail_on_fail && !result.success?
+      if @process_builder.fail_on_fail && result.error?
         raise "Process failed with exit status `#{result.exitstatus}` and output:\n#{result.output}"
       end
       result

--- a/lib/komenda/result.rb
+++ b/lib/komenda/result.rb
@@ -31,6 +31,10 @@ module Komenda
       exitstatus == 0
     end
 
+    def error?
+      exitstatus != 0
+    end
+
     def pid
       @status.pid
     end

--- a/spec/lib/komenda/process_spec.rb
+++ b/spec/lib/komenda/process_spec.rb
@@ -297,6 +297,10 @@ describe Komenda::Process do
         expect(result.success?).to eq(true)
       end
 
+      it 'sets the error' do
+        expect(result.error?).to eq(false)
+      end
+
       it 'sets the PID' do
         expect(result.pid).to be_a(Fixnum)
       end
@@ -330,6 +334,10 @@ describe Komenda::Process do
 
       it 'sets the success' do
         expect(result.success?).to eq(false)
+      end
+
+      it 'sets the error' do
+        expect(result.error?).to eq(true)
       end
     end
 

--- a/spec/lib/komenda/process_spec.rb
+++ b/spec/lib/komenda/process_spec.rb
@@ -302,7 +302,7 @@ describe Komenda::Process do
       end
 
       it 'sets the PID' do
-        expect(result.pid).to be_a(Fixnum)
+        expect(result.pid).to be_a(Integer)
       end
     end
 

--- a/spec/lib/komenda/result_spec.rb
+++ b/spec/lib/komenda/result_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Komenda::Result do
   describe '#initialize' do
     let(:output) { { stdout: 'my stdout', stderr: 'my stderr', combined: 'my combined output' } }
-    let(:status) { double(Process::Status, exitstatus: 12, success?: false, pid: 123) }
+    let(:status) { double(Process::Status, exitstatus: 12, success?: false, error?: true, pid: 123) }
     let(:result) { Komenda::Result.new(output, status) }
 
     it 'sets the output' do
@@ -43,6 +43,26 @@ describe Komenda::Result do
 
       it 'returns false' do
         expect(result.success?).to eq(false)
+      end
+    end
+  end
+
+  describe '#error' do
+    let(:result) { Komenda::Result.new({}, status) }
+
+    context 'when the exitstatus is 0' do
+      let(:status) { double(Process::Status, exitstatus: 0) }
+
+      it 'returns false' do
+        expect(result.error?).to eq(false)
+      end
+    end
+
+    context 'when the exitstatus is 123' do
+      let(:status) { double(Process::Status, exitstatus: 123) }
+
+      it 'returns true' do
+        expect(result.error?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
This PR adds an `error?` predicate to complement `success?`.